### PR TITLE
ex-handler actually works now and includes default print-method

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
                    slipset/deps-deploy {:mvn/version "0.2.2"}}
                   :ns-default slim.lib
                   :exec-args {:lib         com.github.brianium/cog-town
-                              :version     "202506041420"
+                              :version     "202506262123"
                               :url         "https://github.com/brianium/cog-town"
                               :description "agentic workflows with core.async channels"
                               :developer   "Brian Scaturro"}}}}

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -53,6 +53,9 @@
                          (conj resp)
                          (vector resp))))))
 
+  ;;; printing a cog
+  (print echo)
+
   (def shout
     (cogs/cog [] (fn [ctx msg]
                    (let [resp (clojure.string/upper-case msg)]

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -53,9 +53,6 @@
                          (conj resp)
                          (vector resp))))))
 
-  ;;; printing a cog
-  (print echo)
-
   (def shout
     (cogs/cog [] (fn [ctx msg]
                    (let [resp (clojure.string/upper-case msg)]
@@ -189,5 +186,29 @@
   (a/take! neckbeard (fn [{{:keys [dir command]} :content}]
                        (println (apply proc/exec {:dir dir} command))))
   (a/close! neckbeard)
+
+  ;;; Printing and ex-handler
+  (defn ex-handler [^Throwable th]
+    {:type ::error :message (.getMessage th)})
+
+  ;;; ex-handler in with error in transition
+  (def error-prone
+    (cogs/cog [] (fn [_ msg]
+                   (throw (ex-info "Very dumb message" {:msg msg}))) 1 (map identity) ex-handler))
+
+  (print error-prone)
+  (a/put! error-prone "so dumb!")
+  (a/take! error-prone println)
+
+  ;;; ex-handler in out channel transducer
+  (def error-echo
+    (cogs/cog [] (fn [ctx msg]
+                   (let [resp (str "👋 you said: "  msg)]
+                     (-> (conj ctx msg)
+                         (conj resp)
+                         (vector resp)))) 1 (map (fn [v] (throw (ex-info "Bad time" {:v v})))) ex-handler))
+
+  (a/put! error-echo "foo")
+  (a/take! error-echo println)
 
   (do "good in this world"))

--- a/src/cog/town.clj
+++ b/src/cog/town.clj
@@ -34,6 +34,9 @@
   (untap* [_ ch] (async/untap* mult ch))
   (untap-all* [_] (async/untap-all* mult)))
 
+(defmethod print-method Cog [_ writer]
+  (.write writer "#<Cog>"))
+
 ;;; Cog Town
 
 (defn io-chan


### PR DESCRIPTION
- Includes a default `print-method` implementation
- cog ex-handler actually does something now

For now the ex-handler is shared between xf and transition errors. Forks will use the original ex-handler. May look into a more flexible fork API in the future.